### PR TITLE
Needs GHC >= 7.2 due to System.IO.Error.tryIOError

### DIFF
--- a/exceptional.cabal
+++ b/exceptional.cabal
@@ -66,7 +66,7 @@ extra-source-files:
   README.md
 
 library
-  build-depends:       base ==4.*
+  build-depends:       base >= 4.4 && < 5
   exposed-modules:     Control.Exceptional
   default-language:    Haskell98
 


### PR DESCRIPTION
I revised the latest version (http://hackage.haskell.org/package/exceptional/revisions/) so a new release is only needed if you want to bring back the compatibility.
